### PR TITLE
Add package.json file to frontend directory

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "music-analytics-frontend",
+  "version": "1.0.0",
+  "description": "Frontend application for Music Analytics Platform",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "dependencies": {
+    "axios": "^0.21.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-scripts": "4.0.3"
+  },
+  "devDependencies": {
+    "eslint": "^7.32.0",
+    "eslint-plugin-react": "^7.24.0"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}


### PR DESCRIPTION
Add `package.json` file to the `frontend` directory to fix the ENOENT error during `npm install`.

* Create a `package.json` file with the necessary dependencies and scripts for the frontend application.
* Include dependencies such as `axios`, `react`, `react-dom`, and `react-scripts`.
* Add development dependencies like `eslint` and `eslint-plugin-react`.
* Define scripts for starting, building, testing, and ejecting the frontend application.
* Specify browser compatibility settings for production and development environments.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/MusicAnalyticsPlatform/pull/4?shareId=e74a3dc9-c0a0-4dab-9cfc-1007e594e953).