### PR TITLE
Fix React project startup issue by moving index.html to public directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,12 +231,17 @@ By following these detailed setup instructions, you should be able to build, run
    npm install
    ```
 
-3. **Start the development server**:
+3. **Ensure the `index.html` file is in the `public` directory**:
+   ```bash
+   mv src/index.html public/index.html
+   ```
+
+4. **Start the development server**:
    ```bash
    npm start
    ```
 
-4. **Open your browser and navigate to**:
+5. **Open your browser and navigate to**:
    ```
    http://localhost:3000
    ```

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Music Analytics Platform</title>
+</head>
+<body>
+    <div id="root"></div>
+    <script src="index.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Move `index.html` to the `public` directory and update the README.

* **Move `index.html`**:
  - Add `frontend/public/index.html` with the necessary HTML content.
  
* **Update README**:
  - Add instructions to ensure `index.html` is in the `public` directory before starting the development server.
  - Adjust the step numbers accordingly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/MusicAnalyticsPlatform/pull/5?shareId=15aae70a-6e70-47ba-85c1-a718caf58a20).