### PR TITLE
Fix ERR_OSSL_EVP_UNSUPPORTED error in React app with Node.js v20

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "axios": "^0.21.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "4.0.3"
+    "react-scripts": "5.0.1"
   },
   "devDependencies": {
     "eslint": "^7.32.0",
@@ -30,5 +30,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "resolutions": {
+    "webpack": "5.65.0"
   }
 }


### PR DESCRIPTION
Update `react-scripts` to version 5.0.1 and add `resolutions` field in `frontend/package.json`.

* Upgrade `react-scripts` to version 5.0.1 to ensure compatibility with Node.js v20.
* Add `resolutions` field to set `webpack` to version 5.65.0 to address OpenSSL issues.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/MusicAnalyticsPlatform/pull/6?shareId=2540ba0b-0cf2-4783-9fe3-9d4c7aa31db6).