### PR TITLE
Fix the dependency conflict in React project

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,6 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
-    "eslint": "^7.32.0",
     "eslint-plugin-react": "^7.24.0"
   },
   "browserslist": {


### PR DESCRIPTION
Remove `eslint` from `devDependencies` in `frontend/package.json`.

* Ensure `eslint-plugin-react` remains in `devDependencies`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/MusicAnalyticsPlatform/pull/7?shareId=d9674bb9-26bc-4db2-a0d9-fe6b9168f14f).