### PR TITLE
Fix missing distribution parameter in GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: 21
+        distribution: 'temurin'
 
     - name: Build with Maven
       run: mvn clean install

--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ Each microservice communicates through REST APIs, and a high-level diagram is re
 
 3. ** Optionally, use Kubernetes (Minikube or similar) to manage the deployment if desired.**
 
+### GitHub Actions Workflow
+
+In the GitHub Actions workflow configuration file `.github/workflows/ci.yml`, ensure that the `distribution` parameter is specified under the `setup-java` step with the value `temurin`. This is required for the `actions/setup-java` step to function correctly.
+
+Example configuration:
+```yaml
+- name: Set up JDK 21
+  uses: actions/setup-java@v2
+  with:
+    java-version: 21
+    distribution: 'temurin'
+```
+
 ## Microservices Overview
 
 ### UserTrackingService


### PR DESCRIPTION
Add the `distribution` parameter to the GitHub Actions workflow configuration file and update the README.

* **.github/workflows/ci.yml**
  - Add the `distribution` parameter under the `setup-java` step.
  - Set the value of the `distribution` parameter to `temurin`.

* **README.md**
  - Add a note about the `distribution` parameter in the GitHub Actions workflow.
  - Mention the required value `temurin` for the `distribution` parameter.
  - Provide an example configuration for the `setup-java` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/MusicAnalyticsPlatform/pull/13?shareId=97c86704-0ee6-4de3-91a0-0bc9d8b25efd).