### PR TITLE
Fix build failure in GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,18 @@ jobs:
 
     - name: Build with Maven
       run: mvn clean install
+      working-directory: .
 
     - name: Build Docker images
       run: docker-compose build
 
     - name: Run unit tests
       run: mvn test
+      working-directory: .
 
     - name: Run integration tests
       run: mvn verify
+      working-directory: .
 
     - name: Deploy to Kubernetes
       run: |

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,61 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>music-analytics-platform</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>user-tracking-service</module>
+        <module>recommendation-service</module>
+        <module>statistics-service</module>
+        <module>api-gateway</module>
+        <module>eureka-server</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>2.5.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                </plugin>
+                <plugin>
+                    <groupId>com.spotify</groupId>
+                    <artifactId>dockerfile-maven-plugin</artifactId>
+                    <version>1.4.13</version>
+                    <executions>
+                        <execution>
+                            <id>default</id>
+                            <goals>
+                                <goal>build</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <repository>com.example</repository>
+                        <tag>${project.artifactId}</tag>
+                        <buildArgs>
+                            <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
+                        </buildArgs>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>


### PR DESCRIPTION
Add `pom.xml` file to the root directory and update GitHub Actions workflow to navigate to the correct directory before running Maven commands.

* **Add `pom.xml` file**
  - Add a `pom.xml` file to the root directory with the necessary Maven configuration.

* **Update GitHub Actions workflow**
  - Add a `working-directory` parameter to the `Build with Maven` step, set to the root directory.
  - Add a `working-directory` parameter to the `Run unit tests` step, set to the root directory.
  - Add a `working-directory` parameter to the `Run integration tests` step, set to the root directory.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/MusicAnalyticsPlatform?shareId=XXXX-XXXX-XXXX-XXXX).