### PR TITLE
Fix missing dependency versions in pom.xml files

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -12,14 +12,17 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <version>2.5.4</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-gateway</artifactId>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+            <version>3.0.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/eureka-server/pom.xml
+++ b/eureka-server/pom.xml
@@ -12,14 +12,17 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <version>2.5.4</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>2.5.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/recommendation-service/pom.xml
+++ b/recommendation-service/pom.xml
@@ -12,14 +12,17 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <version>2.5.4</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <version>2.5.4</version>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.26</version>
         </dependency>
     </dependencies>
 </project>

--- a/statistics-service/pom.xml
+++ b/statistics-service/pom.xml
@@ -12,14 +12,17 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <version>2.5.4</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <version>2.5.4</version>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.26</version>
         </dependency>
     </dependencies>
 </project>

--- a/user-tracking-service/pom.xml
+++ b/user-tracking-service/pom.xml
@@ -12,14 +12,17 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <version>2.5.4</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <version>2.5.4</version>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.26</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Add missing dependency versions in `pom.xml` files to fix build failure.

* **api-gateway/pom.xml**
  - Add version `2.5.4` for `spring-boot-starter-web` dependency.
  - Add version `3.0.3` for `spring-cloud-starter-gateway` dependency.
  - Add version `3.0.3` for `spring-cloud-starter-netflix-eureka-client` dependency.

* **eureka-server/pom.xml**
  - Add version `2.5.4` for `spring-boot-starter-web` dependency.
  - Add version `3.0.3` for `spring-cloud-starter-netflix-eureka-server` dependency.
  - Add version `2.5.4` for `spring-boot-starter-actuator` dependency.

* **recommendation-service/pom.xml**
  - Add version `2.5.4` for `spring-boot-starter-web` dependency.
  - Add version `2.5.4` for `spring-boot-starter-data-jpa` dependency.
  - Add version `8.0.26` for `mysql-connector-java` dependency.

* **statistics-service/pom.xml**
  - Add version `2.5.4` for `spring-boot-starter-web` dependency.
  - Add version `2.5.4` for `spring-boot-starter-data-jpa` dependency.
  - Add version `8.0.26` for `mysql-connector-java` dependency.

* **user-tracking-service/pom.xml**
  - Add version `2.5.4` for `spring-boot-starter-web` dependency.
  - Add version `2.5.4` for `spring-boot-starter-data-jpa` dependency.
  - Add version `8.0.26` for `mysql-connector-java` dependency.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/MusicAnalyticsPlatform/pull/16?shareId=7684235a-3c9a-4e61-b3ea-357c327208af).