### PR TITLE
Fix build issue and add instructions to run the program

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
       run: npm test
       working-directory: ./frontend
 
+    - name: Start frontend
+      run: npm start
+      working-directory: ./frontend
+
     - name: Set up database
       run: |
         docker-compose up -d db

--- a/README.md
+++ b/README.md
@@ -75,6 +75,31 @@ Each microservice communicates through REST APIs, and a high-level diagram is re
 
 3. ** Optionally, use Kubernetes (Minikube or similar) to manage the deployment if desired.**
 
+4. **Navigate to the `frontend` directory**:
+   ```bash
+   cd frontend
+   ```
+
+5. **Install the dependencies**:
+   ```bash
+   npm install
+   ```
+
+6. **Build the frontend application**:
+   ```bash
+   npm run build
+   ```
+
+7. **Start the frontend application**:
+   ```bash
+   npm start
+   ```
+
+8. **Open your browser and navigate to**:
+   ```
+   http://localhost:3000
+   ```
+
 ### GitHub Actions Workflow
 
 In the GitHub Actions workflow configuration file `.github/workflows/ci.yml`, ensure that the `distribution` parameter is specified under the `setup-java` step with the value `temurin`. This is required for the `actions/setup-java` step to function correctly.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,8 +18,7 @@
     "bootstrap": "^5.1.3"
   },
   "devDependencies": {
-    "eslint-plugin-react": "^7.24.0",
-    "react-scripts": "5.0.1"
+    "eslint-plugin-react": "^7.24.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Update the CI/CD pipeline and documentation to fix the build process and provide instructions on running the program.

* **frontend/package.json**
  - Remove `react-scripts` from `devDependencies`.

* **.github/workflows/ci.yml**
  - Add a step to start the frontend application using `npm start`.

* **README.md**
  - Add instructions on how to navigate to the `frontend` directory, install dependencies, build the frontend application, start the frontend application, and open the application in a browser.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/MusicAnalyticsPlatform/pull/19?shareId=4981e59d-562c-486c-a6c1-e8103098a5cc).