### PR TITLE
Update Maven compiler options to use Java 8

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -25,4 +25,18 @@
             <version>3.0.3</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/eureka-server/pom.xml
+++ b/eureka-server/pom.xml
@@ -25,4 +25,18 @@
             <version>2.5.4</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,15 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                    <configuration>
+                        <source>8</source>
+                        <target>8</target>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/recommendation-service/pom.xml
+++ b/recommendation-service/pom.xml
@@ -25,4 +25,18 @@
             <version>8.0.26</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/statistics-service/pom.xml
+++ b/statistics-service/pom.xml
@@ -25,4 +25,18 @@
             <version>8.0.26</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/user-tracking-service/pom.xml
+++ b/user-tracking-service/pom.xml
@@ -25,4 +25,18 @@
             <version>8.0.26</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Update Maven compiler plugin configuration to use Java 8 in multiple `pom.xml` files.

* **api-gateway/pom.xml**
  - Add `<source>8</source>` and `<target>8</target>` to the `<configuration>` section of the `maven-compiler-plugin`.
* **eureka-server/pom.xml**
  - Add `<source>8</source>` and `<target>8</target>` to the `<configuration>` section of the `maven-compiler-plugin`.
* **recommendation-service/pom.xml**
  - Add `<source>8</source>` and `<target>8</target>` to the `<configuration>` section of the `maven-compiler-plugin`.
* **statistics-service/pom.xml**
  - Add `<source>8</source>` and `<target>8</target>` to the `<configuration>` section of the `maven-compiler-plugin`.
* **user-tracking-service/pom.xml**
  - Add `<source>8</source>` and `<target>8</target>` to the `<configuration>` section of the `maven-compiler-plugin`.
* **pom.xml**
  - Add `<source>8</source>` and `<target>8</target>` to the `<configuration>` section of the `maven-compiler-plugin`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/MusicAnalyticsPlatform/pull/20?shareId=e318ba2f-8020-446c-97e8-f5b429b58628).