### PR TITLE
Fix react-router-dom module not found error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,10 @@ jobs:
       run: npm install
       working-directory: ./frontend
 
+    - name: Install react-router-dom
+      run: npm install react-router-dom
+      working-directory: ./frontend
+
     - name: Install react-scripts globally
       run: npm install -g react-scripts
 


### PR DESCRIPTION
Add a step to install `react-router-dom` in the CI workflow.

* **CI Workflow**:
  - Add a step to install `react-router-dom` after the `Install frontend dependencies` step in `.github/workflows/ci.yml`.
  - Specify the working directory as `./frontend`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/MusicAnalyticsPlatform/pull/22?shareId=b51c9344-62dc-4ccf-b27e-82b2d4790ab6).