### PR TITLE
Update react dependencies to resolve conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,6 @@ jobs:
       run: npm install
       working-directory: ./frontend
 
-    - name: Install react-router-dom
-      run: npm install react-router-dom
-      working-directory: ./frontend
-
     - name: Install react-scripts globally
       run: npm install -g react-scripts
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,11 +11,12 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-scripts": "5.0.1",
     "react-bootstrap": "^1.6.1",
-    "bootstrap": "^5.1.3"
+    "bootstrap": "^5.1.3",
+    "react-router-dom": "^7.1.1"
   },
   "devDependencies": {
     "eslint-plugin-react": "^7.24.0"


### PR DESCRIPTION
Resolve dependency conflict between `react` and `react-router-dom`.

* Update `react` version to `^18.0.0` in `frontend/package.json`.
* Update `react-dom` version to `^18.0.0` in `frontend/package.json`.
* Add `react-router-dom` version `^7.1.1` as a dependency in `frontend/package.json`.
* Remove the step to install `react-router-dom` in `.github/workflows/ci.yml`.
* Ensure the `npm install` step is present in the `frontend` directory in `.github/workflows/ci.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/MusicAnalyticsPlatform/pull/24?shareId=595c2e7f-6681-4e6d-87c6-478c76e1bb1b).