### PR TITLE
Add Dockerfiles for microservices

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,0 +1,28 @@
+# Use an official Maven image to build the application
+FROM maven:3.8.4-openjdk-11 AS build
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the pom.xml file and download the dependencies
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+# Copy the source code and build the application
+COPY src ./src
+RUN mvn package -DskipTests
+
+# Use an official OpenJDK image to run the application
+FROM openjdk:11-jre-slim
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the built JAR file from the build stage
+COPY --from=build /app/target/api-gateway-1.0-SNAPSHOT.jar app.jar
+
+# Expose the port that the application will run on
+EXPOSE 8080
+
+# Set the entry point to run the application
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -37,6 +37,26 @@
                     <target>8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <version>1.4.13</version>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <repository>com.example</repository>
+                    <tag>${project.artifactId}</tag>
+                    <buildArgs>
+                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
+                    </buildArgs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Build Maven project
+mvn clean install
+
+# Build Docker images
+services=("eureka-server" "recommendation-service" "statistics-service" "api-gateway" "user-tracking-service")
+for service in "${services[@]}"; do
+  echo "Building Docker image for $service..."
+  cd $service
+  docker build -t $service .
+  cd ..
+done
+
+# Run Docker Compose
+docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3.8'
 
 services:
   user-tracking-service:
-    image: user-tracking-service
+    image: user-tracking-service:latest
+    build:
+      context: ./user-tracking-service
     ports:
       - "8081:8081"
     environment:
@@ -13,7 +15,9 @@ services:
       - user-tracking-data:/data
 
   recommendation-service:
-    image: recommendation-service
+    image: recommendation-service:latest
+    build:
+      context: ./recommendation-service
     ports:
       - "8082:8082"
     environment:
@@ -24,7 +28,9 @@ services:
       - recommendation-data:/data
 
   statistics-service:
-    image: statistics-service
+    image: statistics-service:latest
+    build:
+      context: ./statistics-service
     ports:
       - "8083:8083"
     environment:
@@ -35,7 +41,9 @@ services:
       - statistics-data:/data
 
   api-gateway:
-    image: api-gateway
+    image: api-gateway:latest
+    build:
+      context: ./api-gateway
     ports:
       - "8080:8080"
     environment:
@@ -44,7 +52,9 @@ services:
       - eureka-server
 
   eureka-server:
-    image: eureka-server
+    image: eureka-server:latest
+    build:
+      context: ./eureka-server
     ports:
       - "8761:8761"
     environment:

--- a/eureka-server/Dockerfile
+++ b/eureka-server/Dockerfile
@@ -1,0 +1,28 @@
+# Use an official Maven image to build the application
+FROM maven:3.8.4-openjdk-11 AS build
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the pom.xml file and download the dependencies
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+# Copy the source code and build the application
+COPY src ./src
+RUN mvn package -DskipTests
+
+# Use an official OpenJDK image to run the application
+FROM openjdk:11-jre-slim
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the built JAR file from the build stage
+COPY --from=build /app/target/eureka-server-1.0-SNAPSHOT.jar app.jar
+
+# Expose the port that the application will run on
+EXPOSE 8761
+
+# Set the entry point to run the application
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/eureka-server/pom.xml
+++ b/eureka-server/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://www.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.example</groupId>
@@ -35,6 +35,26 @@
                 <configuration>
                     <source>8</source>
                     <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <version>1.4.13</version>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <repository>com.example</repository>
+                    <tag>${project.artifactId}</tag>
+                    <buildArgs>
+                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
+                    </buildArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/recommendation-service/Dockerfile
+++ b/recommendation-service/Dockerfile
@@ -1,0 +1,28 @@
+# Use an official Maven image to build the application
+FROM maven:3.8.4-openjdk-11 AS build
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the pom.xml file and download the dependencies
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+# Copy the source code and build the application
+COPY src ./src
+RUN mvn package -DskipTests
+
+# Use an official OpenJDK image to run the application
+FROM openjdk:11-jre-slim
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the built JAR file from the build stage
+COPY --from=build /app/target/recommendation-service-1.0-SNAPSHOT.jar app.jar
+
+# Expose the port that the application will run on
+EXPOSE 8082
+
+# Set the entry point to run the application
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/recommendation-service/pom.xml
+++ b/recommendation-service/pom.xml
@@ -37,6 +37,26 @@
                     <target>8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <version>1.4.13</version>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <repository>com.example</repository>
+                    <tag>${project.artifactId}</tag>
+                    <buildArgs>
+                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
+                    </buildArgs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/statistics-service/Dockerfile
+++ b/statistics-service/Dockerfile
@@ -1,0 +1,28 @@
+# Use an official Maven image to build the application
+FROM maven:3.8.4-openjdk-11 AS build
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the pom.xml file and download the dependencies
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+# Copy the source code and build the application
+COPY src ./src
+RUN mvn package -DskipTests
+
+# Use an official OpenJDK image to run the application
+FROM openjdk:11-jre-slim
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the built JAR file from the build stage
+COPY --from=build /app/target/statistics-service-1.0-SNAPSHOT.jar app.jar
+
+# Expose the port that the application will run on
+EXPOSE 8083
+
+# Set the entry point to run the application
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/statistics-service/pom.xml
+++ b/statistics-service/pom.xml
@@ -37,6 +37,26 @@
                     <target>8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <version>1.4.13</version>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <repository>com.example</repository>
+                    <tag>${project.artifactId}</tag>
+                    <buildArgs>
+                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
+                    </buildArgs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/user-tracking-service/Dockerfile
+++ b/user-tracking-service/Dockerfile
@@ -1,0 +1,28 @@
+# Use an official Maven image to build the application
+FROM maven:3.8.4-openjdk-11 AS build
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the pom.xml file and download the dependencies
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+# Copy the source code and build the application
+COPY src ./src
+RUN mvn package -DskipTests
+
+# Use an official OpenJDK image to run the application
+FROM openjdk:11-jre-slim
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the built JAR file from the build stage
+COPY --from=build /app/target/user-tracking-service-1.0-SNAPSHOT.jar app.jar
+
+# Expose the port that the application will run on
+EXPOSE 8081
+
+# Set the entry point to run the application
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/user-tracking-service/pom.xml
+++ b/user-tracking-service/pom.xml
@@ -37,6 +37,26 @@
                     <target>8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <version>1.4.13</version>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <repository>com.example</repository>
+                    <tag>${project.artifactId}</tag>
+                    <buildArgs>
+                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
+                    </buildArgs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Add Dockerfiles for each microservice and update related files to build and run Docker images.

* **Dockerfiles**:
  - Add `api-gateway/Dockerfile` to build the `api-gateway` service using Maven and set the entry point to run the service.
  - Add `eureka-server/Dockerfile` to build the `eureka-server` service using Maven and set the entry point to run the service.
  - Add `recommendation-service/Dockerfile` to build the `recommendation-service` service using Maven and set the entry point to run the service.
  - Add `statistics-service/Dockerfile` to build the `statistics-service` service using Maven and set the entry point to run the service.
  - Add `user-tracking-service/Dockerfile` to build the `user-tracking-service` service using Maven and set the entry point to run the service.

* **Build and Run Script**:
  - Add `build_and_run.sh` script to build Docker images for each service and run Docker Compose.

* **Docker Compose**:
  - Update `docker-compose.yml` to use the newly built Docker images and add build contexts for each service.

* **Maven Configuration**:
  - Update `api-gateway/pom.xml`, `eureka-server/pom.xml`, `recommendation-service/pom.xml`, `statistics-service/pom.xml`, and `user-tracking-service/pom.xml` to add Docker plugin configuration for building Docker images.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/MusicAnalyticsPlatform/pull/29?shareId=f21402f6-4f93-4e39-aa93-7388de514b1c).