### PR TITLE
Add Docker support for frontend service

### DIFF
--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -4,7 +4,7 @@
 mvn clean install
 
 # Build Docker images
-services=("eureka-server" "recommendation-service" "statistics-service" "api-gateway" "user-tracking-service")
+services=("eureka-server" "recommendation-service" "statistics-service" "api-gateway" "user-tracking-service" "frontend")
 for service in "${services[@]}"; do
   echo "Building Docker image for $service..."
   cd $service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,13 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=docker
 
+  frontend:
+    image: frontend:latest
+    build:
+      context: ./frontend
+    ports:
+      - "3000:3000"
+
 volumes:
   user-tracking-data:
   recommendation-data:

--- a/eureka-server/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst
+++ b/eureka-server/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst
@@ -1,1 +1,0 @@
-com/example/eurekaserver/EurekaServerApplication.class

--- a/eureka-server/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
+++ b/eureka-server/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
@@ -1,1 +1,0 @@
-/workspaces/MusicAnalyticsPlatform/eureka-server/src/main/java/com/example/eurekaserver/EurekaServerApplication.java

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official Node.js image to build the application
+FROM node:14
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the package.json and package-lock.json files and install dependencies
+COPY package*.json ./
+RUN npm install
+
+# Copy the source code and build the application
+COPY . .
+RUN npm run build
+
+# Expose port 3000 and set the entry point to run the application
+EXPOSE 3000
+CMD ["npm", "start"]


### PR DESCRIPTION
Add frontend service to Docker setup and update build script.

* **build_and_run.sh**
  - Update the script to include the frontend service.
  - Add a step to build the frontend Docker image.
  - Add a step to run the frontend service using Docker Compose.

* **docker-compose.yml**
  - Add a service definition for the frontend.
  - Set the build context to `./frontend`.
  - Expose port 3000 for the frontend service.

* **frontend/Dockerfile**
  - Use an official Node.js image to build the application.
  - Set the working directory inside the container.
  - Copy the `package.json` and `package-lock.json` files and install dependencies.
  - Copy the source code and build the application.
  - Expose port 3000 and set the entry point to run the application.

* **Deleted files**
  - Remove `eureka-server/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst`.
  - Remove `eureka-server/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/MusicAnalyticsPlatform/pull/30?shareId=52f16828-08f8-450f-b241-f240f5f66e5a).