### PR TITLE
Simplify project by removing sophisticated components

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -37,29 +37,6 @@
                     <target>8</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>1.4.13</version>
-                <configuration>
-                    <!-- Changed dockerDirectory to use a relative path -->
-                    <dockerDirectory>./</dockerDirectory>
-                    <dockerfile>Dockerfile</dockerfile>
-                    <repository>com.example</repository>
-                    <tag>${project.artifactId}</tag>
-                    <buildArgs>
-                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
-                    </buildArgs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/eureka-server/pom.xml
+++ b/eureka-server/pom.xml
@@ -37,28 +37,6 @@
                     <target>8</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>1.4.13</version>
-                <configuration>
-                    <dockerDirectory>/app</dockerDirectory>
-                    <dockerfile>Dockerfile</dockerfile>
-                    <repository>com.example</repository>
-                    <tag>${project.artifactId}</tag>
-                    <buildArgs>
-                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
-                    </buildArgs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,8 +19,6 @@
     "react-router-dom": "^6.0.0"
   },
   "devDependencies": {
-    "eslint-plugin-react": "^7.24.0",
-    "@babel/plugin-proposal-private-property-in-object": "^7.18.6"
   },
   "browserslist": {
     "production": [

--- a/pom.xml
+++ b/pom.xml
@@ -38,37 +38,6 @@
                 <!-- ... Removed dockerfile-maven-plugin to avoid misconfiguration in modules ... -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.1.2</version>
-                    <executions>
-                        <execution>
-                            <id>validate</id>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <configLocation>checkstyle.xml</configLocation>
-                        <encoding>UTF-8</encoding>
-                        <consoleOutput>true</consoleOutput>
-                        <failsOnError>true</failsOnError>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.sonarsource.scanner.maven</groupId>
-                    <artifactId>sonar-maven-plugin</artifactId>
-                    <version>3.9.1.2184</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>sonar</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
                     <configuration>

--- a/recommendation-service/pom.xml
+++ b/recommendation-service/pom.xml
@@ -37,28 +37,6 @@
                     <target>8</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>1.4.13</version>
-                <configuration>
-                    <dockerDirectory>.</dockerDirectory>
-                    <dockerfile>Dockerfile</dockerfile>
-                    <repository>com.example</repository>
-                    <tag>${project.artifactId}</tag>
-                    <buildArgs>
-                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
-                    </buildArgs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/statistics-service/pom.xml
+++ b/statistics-service/pom.xml
@@ -37,29 +37,6 @@
                     <target>8</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>1.4.13</version>
-                <configuration>
-                    <!-- Set dockerDirectory to '.' to fix file location lookup -->
-                    <dockerDirectory>.</dockerDirectory>
-                    <dockerfile>Dockerfile</dockerfile>
-                    <repository>com.example</repository>
-                    <tag>${project.artifactId}</tag>
-                    <buildArgs>
-                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
-                    </buildArgs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/user-tracking-service/pom.xml
+++ b/user-tracking-service/pom.xml
@@ -37,29 +37,6 @@
                     <target>8</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>1.4.13</version>
-                <configuration>
-                    <!-- Set dockerDirectory to '${project.basedir}' to ensure the Dockerfile is found at the module root -->
-                    <dockerDirectory>${project.basedir}</dockerDirectory>
-                    <dockerfile>Dockerfile</dockerfile>
-                    <repository>com.example</repository>
-                    <tag>${project.artifactId}</tag>
-                    <buildArgs>
-                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
-                    </buildArgs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Simplify the project by removing sophisticated and potentially problematic plugins and dependencies.

* **Remove plugins from `pom.xml`**
  - Remove `maven-checkstyle-plugin` to simplify the build process.
  - Remove `sonar-maven-plugin` to simplify the build process.

* **Remove `dockerfile-maven-plugin` from various `pom.xml` files**
  - Remove from `api-gateway/pom.xml`.
  - Remove from `eureka-server/pom.xml`.
  - Remove from `recommendation-service/pom.xml`.
  - Remove from `statistics-service/pom.xml`.
  - Remove from `user-tracking-service/pom.xml`.

* **Remove dependencies from `frontend/package.json`**
  - Remove `eslint-plugin-react`.
  - Remove `@babel/plugin-proposal-private-property-in-object`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/MusicAnalyticsPlatform/pull/34?shareId=38f3b95a-d191-4188-9b92-093f74040e5e).